### PR TITLE
Fix filter empty categories

### DIFF
--- a/src/model/ICategoricalColumn.ts
+++ b/src/model/ICategoricalColumn.ts
@@ -78,7 +78,7 @@ export function toCategories(desc: ICategoricalDesc) {
   }
   const nextColor = colorPool();
   const l = desc.categories.length - 1;
-  const cats = desc.categories.map((cat, i) => toCategory(cat, i / l, nextColor));
+  const cats = desc.categories.filter((cat) => cat !== null).map((cat, i) => toCategory(cat, i / l, nextColor));
   return cats.sort(compareCategory);
 }
 


### PR DESCRIPTION
closes https://github.com/datavisyn/lineup_app/issues/13

**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 


### Summary

Filters the empty categories before creating actual categories.