### PR TITLE
Replace npm script `prepublishOnly` with `prepare`

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "watch": "webpack --mode development --watch --devtool source-map",
     "start": "webpack-dev-server --mode development --devtool source-map",
     "preversion": "npm test",
-    "prepublishOnly": "npm run build",
+    "prepare": "npm run build",
     "release:major": "npm version major && npm publish && git push --follow-tags",
     "release:minor": "npm version minor && npm publish && git push --follow-tags",
     "release:patch": "npm version patch && npm publish && git push --follow-tags",


### PR DESCRIPTION
Coming from https://github.com/datavisyn/lineupjs/pull/20

Related to https://github.com/datavisyn/lineup_app/issues/15

**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 


### Summary
 
Adding the `prepare` script allows to install this repo from git URI:

```
npm install --save git+https://github.com/datavisyn/lineupjs.git
```

Or for instance by modifying the dependency in the `package.json` of [lineup_app](https://github.com/datavisyn/lineup_app/): 

```
  "dependencies": {
    "lineupjs": "github:Caleydo/lineupjs#develop",
  }
```

For further information see:

* https://docs.npmjs.com/misc/scripts
* https://github.com/npm/npm/issues/3055
* Example: https://github.com/tasti/react-linkify/pull/61


**NOTE!**
Using the git URI as dependency will build the LineUp library on `npm install`. Then the whole install process will take longer than usual. It might appear that the installation process is stuck, but it is not! So be patient or run `npm install -logLevel verbose` to get further information about the progress.