### PR TITLE
Decrease margin of histograms

### DIFF
--- a/src/styles/renderer/_histogram.scss
+++ b/src/styles/renderer/_histogram.scss
@@ -51,7 +51,7 @@ span.#{$lu_css_prefix}-mapping-hint {
 .#{$lu_css_prefix}-histogram-bin {
   flex: 1 1 auto;
   position: relative;
-  margin: 0 1px;
+  margin: 0 1px 0 0;
   font-size: x-small;
 
   &[data-filtered=filtered] {


### PR DESCRIPTION
**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 
 * [x] tested with Firefox 52, Firefox 57+, Chrome 64+, MS Edge 16+


### Summary

Reduce the gap between two bars from (in total) 2px to 1px.
Background: With `display:flex` the collapsing margin should already result in 1px gap, but it does not work.

**Column summary before**

![image](https://user-images.githubusercontent.com/5851088/47150258-68547580-d2d6-11e8-9e56-c552c799c7b0.png)

**Column summary after**

![image](https://user-images.githubusercontent.com/5851088/47150309-7b674580-d2d6-11e8-9244-22776f0546ab.png)


**Sidepanel before**

![image](https://user-images.githubusercontent.com/5851088/47150438-e31d9080-d2d6-11e8-92d3-c38f1e602e62.png)


**Sidepanel after**

![image](https://user-images.githubusercontent.com/5851088/47150412-cf722a00-d2d6-11e8-85a4-f23c17a470ce.png)


 
