### PR TITLE
Explitly set return type of DateColumn.compare()

### DIFF
--- a/src/model/DateColumn.ts
+++ b/src/model/DateColumn.ts
@@ -1,6 +1,6 @@
 import {timeFormat, timeParse} from 'd3-time-format';
 import {Category, toolbar, dialogAddons} from './annotations';
-import {IDataRow, IGroupData} from './interfaces';
+import {IDataRow, IGroupData, IGroup} from './interfaces';
 import {FIRST_IS_MISSING, isMissingValue, missingGroup, isUnknown} from './missing';
 import ValueColumn, {IValueColumnDesc, dataLoaded} from './ValueColumn';
 import {widthChanged, labelChanged, metaDataChanged, dirty, dirtyHeader, dirtyValues, rendererTypeChanged, groupRendererChanged, summaryRendererChanged, visibilityChanged} from './Column';
@@ -173,7 +173,7 @@ export default class DateColumn extends ValueColumn<Date> implements IDateColumn
     this.fire([DateColumn.EVENT_GROUPING_CHANGED, Column.EVENT_DIRTY_VALUES, Column.EVENT_DIRTY], bak, value);
   }
 
-  group(row: IDataRow) {
+  group(row: IDataRow): IGroup {
     const v = this.getDate(row);
     if (!v || !(v instanceof Date)) {
       return missingGroup;


### PR DESCRIPTION
Related to https://github.com/datavisyn/tdp_core/issues/138#issuecomment-441655271

**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 
 * [x] tested with Firefox 52, Firefox 57+, Chrome 64+, MS Edge 16+


### Summary
This change sets the return value of `DateColumn.compare()` to avoid the `import()` statement in the `DateColumn.d.ts` file.

The use of import statements in return values is incompatible with TS 2.7.2.
