### PR TITLE
Expose `isGroup()` and `createMappingFunction()` in *.d.ts files

### DIFF
--- a/src/model/MappingFunction.ts
+++ b/src/model/MappingFunction.ts
@@ -258,7 +258,6 @@ export interface IMapAbleDesc {
   colorMapping?: string | ((v: number)=>string) | any;
 }
 
-/** @internal */
 export function createMappingFunction(dump: any): IMappingFunction {
   if (dump.type === 'script') {
     const s = new ScriptMappingFunction();

--- a/src/model/interfaces.ts
+++ b/src/model/interfaces.ts
@@ -100,7 +100,6 @@ export interface IGroupData extends Readonly<IGroup> {
   readonly rows: IDataRow[];
 }
 
-/** @internal */
 export function isGroup(item: IGroupData | IGroupItem): item is IGroupData {
   return item && (<IGroupData>item).name !== undefined; // use .name as separator
 }


### PR DESCRIPTION
Related issue https://github.com/datavisyn/tdp_core/issues/138#issuecomment-441655310

**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 
 * [x] tested with Firefox 52, Firefox 57+, Chrome 64+, MS Edge 16+


### Summary

The functions `isGroup()` and `createMappingFunction()` are exported, but ignored in the *.d.ts files. Removing the `internal` comment should fix this and make it available for the integration in tdp_core.
