### PR TITLE
Fix label for missing values in  `CategoricalStackedDistributionlCellRenderer`

### DIFF
--- a/src/renderer/CategoricalStackedDistributionlCellRenderer.ts
+++ b/src/renderer/CategoricalStackedDistributionlCellRenderer.ts
@@ -120,7 +120,7 @@ function stackedBar(col: ICategoricalColumn, unfilteredHist?: ICategoricalStatis
   };
 
   return {
-    template: `<div>${bins}<div title="Missing Values"></div>`, // no closing div to be able to append things
+    template: `<div>${bins}`, // no closing div to be able to append things
     update: unfilteredHist ? updateUnfiltered : updateSingle
   };
 }

--- a/src/renderer/CategoricalStackedDistributionlCellRenderer.ts
+++ b/src/renderer/CategoricalStackedDistributionlCellRenderer.ts
@@ -97,7 +97,7 @@ function stackedBar(col: ICategoricalColumn, unfilteredHist?: ICategoricalStatis
 
     forEachChild(n, (d: HTMLElement, i) => {
       const y = i >= hist.length ? missing : hist[i].y;
-      const label = cats[i].label;
+      const label = i >= cats.length ? 'Missing Values' : cats[i].label;
       d.style.flexGrow = `${round(total === 0 ? 0 : y, 2)}`;
       d.title = `${label}: ${y}`;
     });
@@ -120,7 +120,7 @@ function stackedBar(col: ICategoricalColumn, unfilteredHist?: ICategoricalStatis
   };
 
   return {
-    template: `<div>${bins}`, // no closing div to be able to append things
+    template: `<div>${bins}<div title="Missing Values"></div>`, // no closing div to be able to append things
     update: unfilteredHist ? updateUnfiltered : updateSingle
   };
 }


### PR DESCRIPTION
closes https://github.com/datavisyn/tdp_core/issues/144

**prerequisites**: 
 * [x] branch is up-to-date with the branch to be merged with, i.e. develop
 * [x] build is successful
 * [x] code is cleaned up and formatted 
 * [x] tested with Firefox 52, Firefox 57+, Chrome 64+, MS Edge 16+

### Summary

Debugging https://github.com/datavisyn/tdp_core/issues/144 revealed that the missing value div is rendered two times:

![image](https://user-images.githubusercontent.com/5851088/49287684-b5fbfa80-f49e-11e8-8572-8a766a3189e6.png)

The first one is added right after mapping the categories:

https://github.com/datavisyn/lineupjs/blob/c0a9ba907f6cb1cd64024958453331a206314c33/src/renderer/CategoricalStackedDistributionlCellRenderer.ts#L91

The other one is introduced in the renderer template.

The duplication leads to a problem, as the renderer iterates over the DOM collection and there are less categories available.

https://github.com/datavisyn/lineupjs/blob/c0a9ba907f6cb1cd64024958453331a206314c33/src/renderer/CategoricalStackedDistributionlCellRenderer.ts#L98-L103

I removed the last div from the renderer template and now the number of children is correct and the bug is fixed:

![image](https://user-images.githubusercontent.com/5851088/49287616-7af9c700-f49e-11e8-8551-c72f635fe106.png)

@sgratzl Please have a look, if my fix has some side effects. Because you know best, if the removed missing value div is used elsewhere. 
